### PR TITLE
fix: Address Werkzeug server runtime error

### DIFF
--- a/app.py
+++ b/app.py
@@ -213,4 +213,4 @@ def handle_sync_pause():
 
 
 if __name__ == '__main__':
-    socketio.run(app, debug=True, host='0.0.0.0', port=5000) # host='0.0.0.0' for accessibility, port 5000
+    socketio.run(app, debug=True, host='0.0.0.0', port=5000, allow_unsafe_werkzeug=True) # host='0.0.0.0' for accessibility, port 5000


### PR DESCRIPTION
Updated `app.py` to include `allow_unsafe_werkzeug=True` in the `socketio.run()` call.

This prevents a `RuntimeError` raised by Werkzeug when running the Flask-SocketIO development server, ensuring the application can start correctly in its Dockerized environment with the current dependencies.